### PR TITLE
Docs: update expect syntax in Pavlov.Syntax.Expect

### DIFF
--- a/lib/syntax/expect.ex
+++ b/lib/syntax/expect.ex
@@ -10,7 +10,7 @@ defmodule Pavlov.Syntax.Expect do
   In this example, `eq` is a typical matcher:
   
   ## Example
-      expect(actual).to eq(expected)
+      expect(actual) |> to_eq(expected)
   """
   def expect(subject) do
     subject


### PR DESCRIPTION
Previously the documentation stated that the RSpec style
`expect(actual).to eq(expected)` would work. However it seems that this
is not possible. The documentation has been updated to reference the
correct way to call the expect function.

Feel free to ignore this if I am not correct, however I did try to call `expect(3).to eq(3)` and got the following:

    iex(3)> Pavlov.Syntax.Expect.expect(3).to eq(3)
    ** (RuntimeError) undefined function: eq/1
