### PR TITLE
Feat/chain to receive

### DIFF
--- a/lib/mocks.ex
+++ b/lib/mocks.ex
@@ -12,6 +12,10 @@ defmodule Pavlov.Mocks do
     end
   """
 
+  alias __MODULE__
+
+  defstruct module: nil
+
   import ExUnit.Callbacks
 
   defmacro __using__(_) do
@@ -36,7 +40,7 @@ defmodule Pavlov.Mocks do
       :meck.unload(module)
     end
 
-    module
+    %Mocks{module: module}
   end
 
   @doc """
@@ -50,15 +54,15 @@ defmodule Pavlov.Mocks do
   simpler syntax:
       allow MyModule |> to_receive(:simple_method)
   """
-  def to_receive(module, mock) when is_list mock do
+  def to_receive(struct = %Mocks{module: module}, mock) when is_list mock do
     {mock, value} = hd(mock)
     :meck.expect(module, mock, value)
-    {module, mock, value}
+    struct
   end
-  def to_receive(module, mock) do
+  def to_receive(struct = %Mocks{module: module}, mock) do
     value = fn -> nil end
     :meck.expect(module, mock, value)
-    {module, mock, value}
+    struct
   end
 
 end

--- a/test/fixtures/mockable.ex
+++ b/test/fixtures/mockable.ex
@@ -5,6 +5,11 @@ defmodule Fixtures.Mockable do
   end
 
   @doc false
+  def do_something_else do
+    {:ok, "did something else"}
+  end
+
+  @doc false
   def do_with_args(arg) do
     arg
   end

--- a/test/mocks_test.exs
+++ b/test/mocks_test.exs
@@ -28,6 +28,21 @@ defmodule PavlovMocksTest do
     it "resets mocks" do
       expect Mockable.do_something |> to_eq({:ok, "did something"})
     end
+
+    it "permits chaining to_receive" do
+      allow(Mockable)
+        |> to_receive(do_something: fn -> :error end)
+        |> to_receive(do_something_else: fn -> :success end)
+
+      result = Mockable.do_something()
+      other_result = Mockable.do_something_else()
+
+      expect Mockable |> to_have_received :do_something
+      expect result |> to_eq(:error)
+
+      expect Mockable |> to_have_received :do_something_else
+      expect other_result |> to_eq(:success)
+    end
   end
 
   context "Stubbing" do


### PR DESCRIPTION
Previously, When mocking multiple functions on the same module, the
syntax was:

```elixir
allow(Mockable) |> to_receive(do_something: fn -> :error end)
Mockable |> to_receive(do_something_else: fn -> :success end)
```

`allow(Mockable)` now returns a struct in the format
`%Pavlov.Mocks{module: Mockable}` this is now the expected argument to
`to_receive` allowing the following:

```elixir
allow(Mockable)
  |> to_receive(do_something: fn -> :error end)
  |> to_receive(do_something_else: fn -> :success end)
```

The first commit breaks the old way of doing this. The second commit fixes it again. If you want to support the old way let me know and I can squash the commits.