### PR TITLE
Readme: fix example code for `before :all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ In this case, `"A test is about to start"` is printed twice to the console.
 Runs the specified code once before any tests run.
 
 ```elixir
-describe "before :each" do
-  before :each do
+describe "before :all" do
+  before :all do
     IO.puts "This suite is about to run"
     :ok
   end


### PR DESCRIPTION
Previously the `before :all` example in the README, contained a
`before :each` example. This has been updated appropriately.