### PR TITLE
Readme: include example of `passthrough` option for mocking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,19 @@ it "gets a page" do
 end
 ```
 
+If you want the mock to retain all other functions in the original module,
+then you will need to pass the `opts` `List argument to the `allow` function
+and include the `:passthrough` value. The `allow` function specifies a default
+`opts` `List` that includes the `:no_link` value. This value should be included
+in the `List` as it ensures that the mock (which is linked to the creating
+process) will unload automatically when a crash occurs.
+
+```elixir
+before :each do
+  allow(HTTPotion, [:no_link, :passthrough]) |> to_receive(get: fn(url) -> "<html></html>" end)
+end
+```
+
 Expectations on mocks also work using `asserts` syntax via the `called` matcher:
 
 ```elixir

--- a/test/mocks_test.exs
+++ b/test/mocks_test.exs
@@ -43,6 +43,22 @@ defmodule PavlovMocksTest do
       expect Mockable |> to_have_received :do_something_else
       expect other_result |> to_eq(:success)
     end
+
+    it "doesn't permit the mock to retain other functions in module" do
+      allow(Mockable)
+        |> to_receive(do_something: fn -> :success end)
+
+        expect fn -> Mockable.do_something_else end |> to_have_raised UndefinedFunctionError
+    end
+
+    context "when the :passthrough option is used" do
+      it "permits the mock to retain other functions in the module" do
+        allow(Mockable, [:no_link, :passthrough])
+          |> to_receive(do_something: fn -> :success end)
+
+          expect fn -> Mockable.do_something_else end |> not_to_have_raised UndefinedFunctionError
+      end
+    end
   end
 
   context "Stubbing" do


### PR DESCRIPTION
When mocking a common requirement is for the mock to retain all other
functions in the original module. The README has been updated to include
information and an example of how this can be achieved.