### PR TITLE
Provides better messages for failing matchers

### DIFF
--- a/lib/matchers/messages.ex
+++ b/lib/matchers/messages.ex
@@ -1,0 +1,56 @@
+defmodule Pavlov.Matchers.Messages do
+
+  def message_for_matcher(matcher_name, [actual, expected], :assertion) do
+    actual = inspect actual
+    expected = inspect expected
+
+    case matcher_name do
+      :eq -> "Expected #{actual} to equal #{expected}"
+      :have_key -> "Expected #{actual} to have key #{expected}"
+      :include -> "Expected #{actual} to include #{expected}"
+      :have_raised -> "Expected function to have raised #{expected}"
+      :have_thrown -> "Expected function to have thrown #{expected}"
+      _ -> "Assertion with #{matcher_name} failed: #{actual}, #{expected}"
+    end
+  end
+  def message_for_matcher(matcher_name, [actual], :assertion) do
+    actual = inspect actual
+
+    case matcher_name do
+      :be_true -> "Expected #{actual} to be true"
+      :be_truthy -> "Expected #{actual} to be truthy"
+      :be_falsey -> "Expected #{actual} to be falsey"
+      :be_nil -> "Expected #{actual} to be nil"
+      :be_empty -> "Expected #{actual} to be empty"
+      :have_exited -> "Expected function to have exited"
+      _ -> "Assertion with #{matcher_name} failed: #{actual}"
+    end
+  end
+  def message_for_matcher(matcher_name, [actual, expected], :refutation) do
+    actual = inspect actual
+    expected = inspect expected
+
+    case matcher_name do
+      :eq -> "Expected #{actual} not to equal #{expected}"
+      :have_key -> "Expected #{actual} not to have key #{expected}"
+      :include -> "Expected #{actual} not to include #{expected}"
+      :have_raised -> "Expected function not to have raised #{expected}"
+      :have_thrown -> "Expected function not to have thrown #{expected}"
+      _ -> "Refutation with #{matcher_name} failed: #{actual}, #{expected}"
+    end
+  end
+  def message_for_matcher(matcher_name, [actual], :refutation) do
+    actual = inspect actual
+
+    case matcher_name do
+      :be_true -> "Expected #{actual} not to be true"
+      :be_truthy -> "Expected #{actual} not to be truthy"
+      :be_falsey -> "Expected #{actual} not to be falsey"
+      :be_nil -> "Expected #{actual} not to be nil"
+      :be_empty -> "Expected #{actual} not to be empty"
+      :have_exited -> "Expected function not to have exited"
+      _ -> "Refutation with #{matcher_name} failed: #{actual}"
+    end
+  end
+
+end

--- a/lib/syntax/expect.ex
+++ b/lib/syntax/expect.ex
@@ -4,11 +4,12 @@ defmodule Pavlov.Syntax.Expect do
   """
 
   import ExUnit.Assertions
+  import Pavlov.Matchers.Messages
 
   @doc """
   Sets an expectation on a value.
   In this example, `eq` is a typical matcher:
-  
+
   ## Example
       expect(actual) |> to_eq(expected)
   """
@@ -28,7 +29,12 @@ defmodule Pavlov.Syntax.Expect do
         _ -> [actual, expected]
       end
 
-      assert apply(Pavlov.Matchers, unquote(method), args)
+      result = apply(Pavlov.Matchers, unquote(method), args)
+
+      case result do
+        false -> flunk message_for_matcher(unquote(:"#{method}"), args, :assertion)
+        _ -> assert result
+      end
     end
   end
 
@@ -44,7 +50,12 @@ defmodule Pavlov.Syntax.Expect do
         _ -> [actual, expected]
       end
 
-      refute apply(Pavlov.Matchers, unquote(method), args)
+      result = apply(Pavlov.Matchers, unquote(method), args)
+
+      case result do
+        true -> flunk message_for_matcher(unquote(:"#{method}"), args, :refutation)
+        _ -> refute result
+      end
     end
   end
 end

--- a/test/syntax/expect_test.exs
+++ b/test/syntax/expect_test.exs
@@ -1,6 +1,7 @@
 defmodule PavlovExpectTest do
   use Pavlov.Case, async: true
   import Pavlov.Syntax.Expect
+  import Pavlov.Matchers.Messages
 
   describe "Matchers" do
     describe ".eq" do
@@ -11,6 +12,20 @@ defmodule PavlovExpectTest do
       it "supports a negative expression" do
         expect 1 |> not_to_eq 2
       end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:eq, [2, 1], :assertion)
+
+        expect message
+          |> to_eq "Expected 2 to equal 1"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:eq, [2, 2], :refutation)
+
+        expect message
+          |> to_eq "Expected 2 not to equal 2"
+      end
     end
 
     describe ".be_true" do
@@ -20,6 +35,20 @@ defmodule PavlovExpectTest do
 
       it "supports a negative expression" do
         expect (1==2) |> not_to_be_true
+      end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:be_true, [false], :assertion)
+
+        expect message
+          |> to_eq "Expected false to be true"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:be_true, [true], :refutation)
+
+        expect message
+          |> to_eq "Expected true not to be true"
       end
     end
 
@@ -34,6 +63,20 @@ defmodule PavlovExpectTest do
         expect false |> not_to_be_truthy
         expect nil |> not_to_be_truthy
       end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:be_truthy, [nil], :assertion)
+
+        expect message
+          |> to_eq "Expected nil to be truthy"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:be_truthy, [nil], :refutation)
+
+        expect message
+          |> to_eq "Expected nil not to be truthy"
+      end
     end
 
     describe ".be_falsey" do
@@ -47,6 +90,20 @@ defmodule PavlovExpectTest do
         expect true |> not_to_be_falsey
         expect "pavlov" |> not_to_be_falsey
       end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:be_falsey, [false], :assertion)
+
+        expect message
+          |> to_eq "Expected false to be falsey"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:be_falsey, [false], :refutation)
+
+        expect message
+          |> to_eq "Expected false not to be falsey"
+      end
     end
 
     describe ".be_nil" do
@@ -56,6 +113,20 @@ defmodule PavlovExpectTest do
 
       it "supports a negative expression" do
         expect "nil" |> not_to_be_nil
+      end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:be_nil, [nil], :assertion)
+
+        expect message
+          |> to_eq "Expected nil to be nil"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:be_nil, [nil], :refutation)
+
+        expect message
+          |> to_eq "Expected nil not to be nil"
       end
     end
 
@@ -68,6 +139,20 @@ defmodule PavlovExpectTest do
       it "supports a negative expression" do
         expect %{:a => 1} |> not_to_have_key :b
         expect [a: 1] |> not_to_have_key :b
+      end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:have_key, [%{:a => 1}, :b], :assertion)
+
+        expect message
+          |> to_eq "Expected %{a: 1} to have key :b"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:have_key, [%{:a => 1}, :b], :refutation)
+
+        expect message
+          |> to_eq "Expected %{a: 1} not to have key :b"
       end
     end
 
@@ -85,6 +170,20 @@ defmodule PavlovExpectTest do
         expect %{:a => 1} |> not_to_be_empty
         expect [a: 1] |> not_to_be_empty
         expect "asd" |> not_to_be_empty
+      end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:be_empty, [%{:a => 1}], :assertion)
+
+        expect message
+          |> to_eq "Expected %{a: 1} to be empty"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:be_empty, [%{:a => 1}], :refutation)
+
+        expect message
+          |> to_eq "Expected %{a: 1} not to be empty"
       end
     end
 
@@ -106,6 +205,20 @@ defmodule PavlovExpectTest do
         expect %{:a => 1} |> not_to_include {:a, 5}
         expect "a string" |> not_to_include "a strict"
       end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:include, [%{:a => 1}, %{:a => 5}], :assertion)
+
+        expect message
+          |> to_eq "Expected %{a: 1} to include %{a: 5}"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:include, [%{:a => 1}, %{:a => 5}], :refutation)
+
+        expect message
+          |> to_eq "Expected %{a: 1} not to include %{a: 5}"
+      end
     end
 
     describe ".have_raised" do
@@ -115,6 +228,20 @@ defmodule PavlovExpectTest do
 
       it "supports a negative expression" do
         expect fn -> 1 + 2 end |> not_to_have_raised ArithmeticError
+      end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:have_raised, [fn -> 1 + "test" end, ArithmeticError], :assertion)
+
+        expect message
+          |> to_eq "Expected function to have raised ArithmeticError"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:have_raised, [fn -> 1 + "test" end, ArithmeticError], :refutation)
+
+        expect message
+          |> to_eq "Expected function not to have raised ArithmeticError"
       end
     end
 
@@ -126,6 +253,20 @@ defmodule PavlovExpectTest do
       it "supports a negative expression" do
         expect fn -> throw("x") end |> not_to_have_thrown "y"
       end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:have_thrown, [fn -> 1 + throw("x") end, "x"], :assertion)
+
+        expect message
+          |> to_eq "Expected function to have thrown \"x\""
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:have_thrown, [fn -> 1 + throw("x") end, "x"], :refutation)
+
+        expect message
+          |> to_eq "Expected function not to have thrown \"x\""
+      end
     end
 
     describe ".have_exited" do
@@ -135,6 +276,20 @@ defmodule PavlovExpectTest do
 
       it "supports a negative expression" do
         expect fn -> :ok end |> not_to_have_exited
+      end
+
+      it "provides a flunk message" do
+        message = message_for_matcher(:have_exited, [fn -> exit "bye!" end], :assertion)
+
+        expect message
+          |> to_eq "Expected function to have exited"
+      end
+
+      it "provides a refutation flunk message" do
+        message = message_for_matcher(:have_exited, [fn -> exit "bye!" end], :refutation)
+
+        expect message
+          |> to_eq "Expected function not to have exited"
       end
     end
   end


### PR DESCRIPTION
Assertions no longer blindly throw messages like "Expected false to be true". This PR introduces custom messages per matcher. It also includes custom messages for refutation matchers (such as `not_to_eq`).