### PR TITLE
Clears .let memoization across test examples

### DIFF
--- a/lib/case.ex
+++ b/lib/case.ex
@@ -147,6 +147,7 @@ defmodule Pavlov.Case do
       Pavlov.Case.__on_definition__(__ENV__, message, pending)
 
       def unquote(message)(unquote(var)) do
+        Pavlov.Utils.Memoize.flush
         unquote(contents)
       end
     end

--- a/lib/utils/memoize.ex
+++ b/lib/utils/memoize.ex
@@ -18,6 +18,10 @@ defmodule Pavlov.Utils.Memoize do
     end
   end
 
+  def flush do
+    ResultTable.flush
+  end
+
   # gen_server keeping results for function calls
   defmodule ResultTable do
     @moduledoc false
@@ -34,6 +38,9 @@ defmodule Pavlov.Utils.Memoize do
         { :reply, :miss, dict }
       end
     end
+    def handle_call({ :flush }, _sender, dict) do
+      { :reply, :hit, Dict.drop(dict, Dict.keys(dict)) }
+    end
 
     def handle_cast({ :put, fun, args, result }, dict) do
       { :noreply, Dict.put(dict, { fun, args }, result) }
@@ -41,5 +48,6 @@ defmodule Pavlov.Utils.Memoize do
 
     def get(fun, args),         do: GenServer.call(:result_table, { :get, fun, args })
     def put(fun, args, result), do: GenServer.cast(:result_table, { :put, fun, args, result })
+    def flush, do: GenServer.call(:result_table, { :flush })
   end
 end

--- a/test/case/case_test.exs
+++ b/test/case/case_test.exs
@@ -69,6 +69,7 @@ defmodule PavlovCaseTest do
     end
 
     it "only invokes the letted block once" do
+      Agent.update(:memoized_let, fn acc -> 0 end)
       something
       something
 


### PR DESCRIPTION
Fix  #16