### PR TITLE
Let statements don't retain memos when used in before callbacks

### DIFF
--- a/lib/case.ex
+++ b/lib/case.ex
@@ -250,8 +250,8 @@ defmodule Pavlov.Case do
       Pavlov.Case.__on_definition__(__ENV__, message, pending)
 
       def unquote(message)(unquote(var)) do
-        Pavlov.Utils.Memoize.flush
         unquote(contents)
+        Pavlov.Utils.Memoize.flush
       end
     end
   end

--- a/test/callbacks_test.exs
+++ b/test/callbacks_test.exs
@@ -42,4 +42,30 @@ defmodule PavlovCallbackTest do
       end
     end
   end
+
+  describe "Lets" do
+    context "before :each" do
+      setup_all do
+        Agent.start_link(fn -> 0 end, name: :memoized_let)
+        :ok
+      end
+
+      let :something do
+        Agent.update(:memoized_let, fn acc -> acc + 1 end)
+        "I am a string"
+      end
+
+      before :each do
+        Agent.update(:memoized_let, fn acc -> 0 end)
+        something
+        :ok
+      end
+
+      it "only invokes the letted block once" do
+        assert Agent.get(:memoized_let, fn acc -> acc end) == 1
+        something
+        assert Agent.get(:memoized_let, fn acc -> acc end) == 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
Here's a failing spec for https://github.com/sproutapp/pavlov/issues/46

Not sure on how to properly implement this
